### PR TITLE
fix(ci): pin renovate action to v46.1.16

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: run
-        uses: renovatebot/github-action@v46
+        uses: renovatebot/github-action@v46.1.16
         with:
           configurationFile: renovate.json
           token: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
## Summary
- `renovatebot/github-action@v46` was unresolvable (the action doesn't publish a floating major-version tag) and broke the weekly renovate workflow for the last 3 runs.
- Pin to the latest exact version, `v46.1.16`.

## Test plan
- [ ] Merge, then trigger the renovate workflow manually (`workflow_dispatch`) and confirm "Set up job" resolves the action and the job runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)